### PR TITLE
removing urlparse because of "&reg" bug turning into "®"

### DIFF
--- a/html_groomer.py
+++ b/html_groomer.py
@@ -650,7 +650,8 @@ class HGElement():
 
     def fixUrl(self, u):
         #TODO fix missing protocol
-        url = urlparse(u.strip())
+        #url = urlparse(u.strip())
+        url = u.strip()
         return url.geturl()
 
     def debug(self, metadata={}):


### PR DESCRIPTION
https://stackoverflow.com/questions/15532252/why-is-reg-being-rendered-as-without-the-bounding-semicolon